### PR TITLE
AgentProfile component fixes

### DIFF
--- a/ui/src/components/HomeNavbar.vue
+++ b/ui/src/components/HomeNavbar.vue
@@ -54,7 +54,7 @@
             class="dropdown-content menu z-40 bg-base-200 text-base-content shadow-md"
           >
             <li>
-              <RouterLink :to="`/agents/${myPubKeyBase64}`">
+              <RouterLink :to="`/my-agent`">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="24"

--- a/ui/src/herd/profiles/MyAgentProfileDetail.vue
+++ b/ui/src/herd/profiles/MyAgentProfileDetail.vue
@@ -1,4 +1,4 @@
-<template>
+<template>      
   <div
     class="w-full min-h-screen flex justify-center bg-base-100"
     style="color: hsl(var(--bc)); --sl-input-help-text-color: hsl(var(--bc)); --sl-input-label-color: hsl(var(--bc));"
@@ -6,9 +6,8 @@
     <div
       class="w-full h-full flex justify-center items-center max-w-md"
     >
-      <profile-detail
-        :agentPubKey="agentPubKey"
-        class="p-8 bg-base-200 text-base-content min-w-[15rem]"
+      <my-profile
+        class="p-8 bg-base-200 text-base-content w-fit min-w-[15rem]"
         style="color: hsl(var(--bc)) !important; --sl-input-help-text-color: hsl(var(--bc)); --sl-input-label-color: hsl(var(--bc));"
       />
     </div>
@@ -16,13 +15,4 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-import { useRoute } from 'vue-router';
-import { decodeHashFromBase64 } from '@holochain/client';
-
-const route = useRoute();
-
-const agentPubKey = computed(() => {
-  return decodeHashFromBase64(route.params.agentPubKeyString as string);
-});
 </script>

--- a/ui/src/routes.ts
+++ b/ui/src/routes.ts
@@ -5,6 +5,7 @@ import CreateHerd from './herd/herds/CreateHerd.vue';
 import WateringHole from './herd/herds/WateringHole.vue';
 import HerdDetail from './herd/herds/HerdDetail.vue';
 import AgentProfileDetail from './herd/profiles/AgentProfileDetail.vue';
+import MyAgentProfileDetail from './herd/profiles/MyAgentProfileDetail.vue';
 
 const herd_routes = [
   { path: '', component: AllPosts },
@@ -15,6 +16,7 @@ const herd_routes = [
 export default [
   { path: '', component: WateringHole },
   { path: '/agents/:agentPubKeyString', component: AgentProfileDetail },
+  { path: '/my-agent', component: MyAgentProfileDetail },
   { path: '/herds/create', component: CreateHerd },
   { path: '/herds/private/:password', component: HerdDetail, children: herd_routes },
   { path: '/herds/:listingHashString', component: HerdDetail, children: herd_routes },


### PR DESCRIPTION
- *mostly* resolves the issue where profile-detail does not reactively update upon editing a profile via my-profile. It still happens sometimes and I can't figure out why, but this definitely reduces how often it appears.
- minor improvements to profile component styling (set min width)
- Split profile route/component into two: one for my profile, one for another agent's profile