### PR TITLE
ref(validate_create_listing)

### DIFF
--- a/dnas/directory/zomes/integrity/directory/src/listing.rs
+++ b/dnas/directory/zomes/integrity/directory/src/listing.rs
@@ -27,7 +27,7 @@ pub fn validate_create_listing(
     }
     
     // Listing title contains no whitespace, is alphanumeric
-    if !listing.title.chars().all(|c| !char::is_whitespace(c) && char::is_alphanumeric(c)) {
+    if !listing.title.chars().all(|c| char::is_alphanumeric(c)) {
         return Ok(ValidateCallbackResult::Invalid("Title can only contain alphanumeric characters, and no spaces".into()));
     }
 


### PR DESCRIPTION
`!char::is_whitespace(c)` check is already covered by `char::is_alphanumeric(c)` 